### PR TITLE
Convert absolute into relative symlinks

### DIFF
--- a/AppImage/srb2/build.sh
+++ b/AppImage/srb2/build.sh
@@ -49,7 +49,8 @@ sed -i 's|exec|cd share/games/SRB2; exec|' "$appdir"/AppRun
 
 ############################################
 
-rdfind -makesymlinks true . # Replace duplicate files with symlinks
+rdfind -makesymlinks true . # Replace duplicate files with absolute symlinks
+symlinks -c . # Convert absolute into relative symlinks
 
 "$tools_dir"/appimagetool.AppImage "$appdir"
 mv *.AppImage "$out_dir"/


### PR DESCRIPTION
Thanks to @Samueru-sama for brining this topic up.

https://manpages.ubuntu.com/manpages/trusty/man1/symlinks.1.html

```
       -c     convert  absolute  links  (within  the  same  filesystem)  to relative links.  This
              permits links to maintain their validity regardless of the mount point used for the
              filesystem  --  a desirable setup in most cases.  This option also causes any messy
              links to be cleaned up, and, if -s was also specified, then lengthy links are  also
              shortened.  Links affected by -c are prefixed with changed in the output.
```


But the package is not available in Alpine Linux?

Can we get it packaged there?

[ci skip]